### PR TITLE
renovate: try higher stabilityDays

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,5 @@
     "enabled": true
   },
   "automerge": true,
-  "stabilityDays": 1
+  "stabilityDays": 3
 }


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/ says:

> If you have both automerge as well as stabilityDays enabled,
> it means that PRs will be created immediately but automerging
> will be delayed until X days have passed.

However, I am not seeing this behavior with stabilityDays=1,
e.g. https://github.com/rohanpm/ssh-prometheus-exporter/pull/6
was created then merged ~1 hour later.

Maybe it just doesn't work, but let's first try bumping it up to
three in case there is some ambiguity around what exactly
constitutes a "day" here (e.g. with updates happening just before
or after a date rollover).